### PR TITLE
Unify OSM Element Type Support in sweep.py

### DIFF
--- a/webhook/sweep.py
+++ b/webhook/sweep.py
@@ -38,8 +38,8 @@ def github_request(url: str, github_token: str) -> typing.Any:
         return json.loads(response.read())
 
 
-def collect_relation_ids(repo: str, github_token: str) -> set[int]:
-    """Return all OSM relation IDs referenced across open PRs and main branch."""
+def collect_osm_refs(repo: str, github_token: str) -> set[tuple[str, int]]:
+    """Return all OSM element refs referenced across open PRs and main branch."""
     shas: set[str] = set()
 
     # Open PRs
@@ -61,7 +61,7 @@ def collect_relation_ids(repo: str, github_token: str) -> set[int]:
     if main_sha:
         shas.add(main_sha)
 
-    relation_ids: set[int] = set()
+    osm_refs: set[tuple[str, int]] = set()
     for sha in shas:
         tree = github_request(
             f'https://api.github.com/repos/{repo}/git/trees/{sha}?recursive=0',
@@ -77,14 +77,14 @@ def collect_relation_ids(repo: str, github_token: str) -> set[int]:
                 )
                 with urllib.request.urlopen(raw_req) as resp:
                     config = yaml.safe_load(resp.read())
-                relation_ids.update(_extract_relation_ids(config))
+                osm_refs.update(_extract_osm_refs(config))
 
-    return relation_ids
+    return osm_refs
 
 
-def _extract_relation_ids(config: typing.Any) -> list[int]:
-    """Walk config dict and return all relation IDs."""
-    ids: list[int] = []
+def _extract_osm_refs(config: typing.Any) -> list[tuple[str, int]]:
+    """Walk config dict and return all OSM element refs."""
+    ids: list[tuple[str, int]] = []
     if not isinstance(config, dict):
         return ids
     for country_val in config.values():
@@ -100,42 +100,42 @@ def _extract_relation_ids(config: typing.Any) -> list[int]:
     return ids
 
 
-def _scan_shape_list(shape_list: typing.Any) -> list[int]:
-    ids: list[int] = []
+def _scan_shape_list(shape_list: typing.Any) -> list[tuple[str, int]]:
+    refs: list[tuple[str, int]] = []
     if not isinstance(shape_list, list):
-        return ids
+        return refs
     for item in shape_list:
-        if isinstance(item, list) and len(item) >= 3 and item[1] == 'relation' and isinstance(item[2], int):
-            ids.append(item[2])
-    return ids
+        if isinstance(item, list) and len(item) >= 3 and isinstance(item[1], str) and isinstance(item[2], int):
+            refs.append((item[1], item[2]))
+    return refs
 
 
-def find_stale_relations(
-    relation_ids: set[int],
+def find_stale_elements(
+    osm_refs: set[tuple[str, int]],
     data_bucket: str,
     max_age_seconds: float = 86400.0,
-) -> list[int]:
-    """Return relation IDs whose S3 cache is missing or older than max_age_seconds."""
+) -> list[tuple[str, int]]:
+    """Return element refs whose S3 cache is missing or older than max_age_seconds."""
     s3 = boto3.client('s3')
     now = time.time()
-    stale: list[int] = []
-    for osm_id in relation_ids:
-        key = f'cache/relation/{osm_id}.osm.xml.gz'
+    stale: list[tuple[str, int]] = []
+    for el_type, osm_id in osm_refs:
+        key = f'cache/{el_type}/{osm_id}.osm.xml.gz'
         try:
             head = s3.head_object(Bucket=data_bucket, Key=key)
             age = now - head['LastModified'].timestamp()
             if age > max_age_seconds:
-                stale.append(osm_id)
+                stale.append((el_type, osm_id))
         except Exception as exc:
             # Accept both botocore ClientError 404 and any other missing-object signal
-            logging.debug(f'Cache miss for relation {osm_id}: {exc}')
-            stale.append(osm_id)
+            logging.debug(f'Cache miss for {el_type}/{osm_id}: {exc}')
+            stale.append((el_type, osm_id))
     return stale
 
 
-def download_relation(osm_id: int) -> bytes:
-    """Download relation XML from OSM API with retries."""
-    url = f'https://api.openstreetmap.org/api/0.6/relation/{osm_id}/full'
+def download_element(el_type: str, osm_id: int) -> bytes:
+    """Download element XML from OSM API with retries."""
+    url = f'https://api.openstreetmap.org/api/0.6/{el_type}/{osm_id}/full'
     last_exc: Exception = RuntimeError('no attempts made')
     for delay in (None, 10, 20):
         if delay is not None:
@@ -152,9 +152,9 @@ def download_relation(osm_id: int) -> bytes:
     raise last_exc
 
 
-def upload_to_cache(osm_id: int, data: bytes, data_bucket: str) -> None:
+def upload_to_cache(el_type: str, osm_id: int, data: bytes, data_bucket: str) -> None:
     s3 = boto3.client('s3')
-    key = f'cache/relation/{osm_id}.osm.xml.gz'
+    key = f'cache/{el_type}/{osm_id}.osm.xml.gz'
     s3.put_object(
         Bucket=data_bucket,
         Key=key,
@@ -176,23 +176,24 @@ def lambda_handler(event: dict[str, typing.Any], context: typing.Any) -> dict[st
         return {'statusCode': 500, 'error': 'Missing GITHUB_SECRET_ARN, DATA_BUCKET, or GITHUB_REPO'}
 
     github_token = fetch_github_token(github_secret_arn)
-    relation_ids = collect_relation_ids(github_repo, github_token)
-    logging.info(f'Found {len(relation_ids)} unique relation IDs across all branches')
+    osm_refs = collect_osm_refs(github_repo, github_token)
+    logging.info(f'Found {len(osm_refs)} unique OSM element refs across all branches')
 
-    stale = find_stale_relations(relation_ids, data_bucket)
-    logging.info(f'{len(stale)} stale relations out of {len(relation_ids)}')
+    stale = find_stale_elements(osm_refs, data_bucket)
+    logging.info(f'{len(stale)} stale elements out of {len(osm_refs)}')
 
     if not stale:
-        logging.info('No stale relations; nothing to do')
-        return {'statusCode': 200, 'message': 'No stale relations'}
+        logging.info('No stale elements; nothing to do')
+        return {'statusCode': 200, 'message': 'No stale elements'}
 
     choices = random.choices(stale, k=min(3, len(stale)))
     for chosen in choices:
-        logging.info(f'Selected relation {chosen} for refresh')
-        data = download_relation(chosen)
-        upload_to_cache(chosen, data, data_bucket)
+        el_type, osm_id = chosen
+        logging.info(f'Selected {el_type}/{osm_id} for refresh')
+        data = download_element(el_type, osm_id)
+        upload_to_cache(el_type, osm_id, data, data_bucket)
 
-    return {'statusCode': 200, 'message': f"Cached relations {', '.join(map(str, choices))}"}
+    return {'statusCode': 200, 'message': f"Cached elements {', '.join(f'{el_type}/{osm_id}' for el_type, osm_id in choices)}"}
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +247,7 @@ class TestSweepFunction(unittest.TestCase):
     @unittest.mock.patch('boto3.client')
     @unittest.mock.patch('time.sleep')
     @unittest.mock.patch('urllib.request.urlopen')
-    def test_picks_and_uploads_stale_relation(
+    def test_picks_and_uploads_stale_element(
         self, mock_urlopen: typing.Any, mock_sleep: typing.Any, mock_boto_client: typing.Any
     ) -> None:
         import datetime
@@ -275,7 +276,7 @@ class TestSweepFunction(unittest.TestCase):
         mock_s3.put_object.assert_called_once()
         call_kwargs = mock_s3.put_object.call_args[1]
         self.assertEqual(call_kwargs['Bucket'], 'test-bucket')
-        self.assertIn('184633', call_kwargs['Key'])
+        self.assertIn('relation/184633', call_kwargs['Key'])
 
     @unittest.mock.patch.dict(os.environ, {
         'GITHUB_SECRET_ARN': 'arn:aws:secretsmanager:us-east-1:123:secret:tok',
@@ -313,7 +314,7 @@ class TestSweepFunction(unittest.TestCase):
         result = lambda_handler({}, unittest.mock.MagicMock())
         self.assertEqual(result['statusCode'], 500)
 
-    def test_extract_relation_ids_base_and_perspectives(self) -> None:
+    def test_extract_osm_refs_base_and_perspectives(self) -> None:
         config = {
             'FRA': {
                 'base': [
@@ -325,17 +326,56 @@ class TestSweepFunction(unittest.TestCase):
                 },
             }
         }
-        ids = _extract_relation_ids(config)
-        self.assertIn(2202162, ids)
-        self.assertIn(365331, ids)
+        ids = _extract_osm_refs(config)
+        self.assertIn(('relation', 2202162), ids)
+        self.assertIn(('relation', 365331), ids)
 
-    def test_scan_shape_list_ignores_non_relation(self) -> None:
+    def test_scan_shape_list_returns_way_and_relation(self) -> None:
         shape_list = [
             ['plus', 'way', 12345],
             ['plus', 'relation', 99999],
         ]
-        ids = _scan_shape_list(shape_list)
-        self.assertEqual(ids, [99999])
+        refs = _scan_shape_list(shape_list)
+        self.assertIn(('way', 12345), refs)
+        self.assertIn(('relation', 99999), refs)
+
+    def test_scan_shape_list_skips_malformed(self) -> None:
+        shape_list = [
+            ['plus', 'relation'],         # too short
+            ['plus', 'relation', '999'],  # string osm_id
+            'not-a-list',                 # non-list item
+        ]
+        refs = _scan_shape_list(shape_list)
+        self.assertEqual(refs, [])
+
+    @unittest.mock.patch.dict(os.environ, {
+        'GITHUB_SECRET_ARN': 'arn:aws:secretsmanager:us-east-1:123:secret:tok',
+        'DATA_BUCKET': 'test-bucket',
+        'GITHUB_REPO': 'org/repo',
+    })
+    @unittest.mock.patch('boto3.client')
+    @unittest.mock.patch('time.sleep')
+    @unittest.mock.patch('urllib.request.urlopen')
+    def test_way_element_is_cached(
+        self, mock_urlopen: typing.Any, mock_sleep: typing.Any, mock_boto_client: typing.Any
+    ) -> None:
+        client_factory, mock_s3 = self._make_mock_boto_client()
+        mock_boto_client.side_effect = client_factory
+
+        pulls_resp = _make_url_mock(json.dumps([{'head': {'sha': 'abc123'}}]).encode())
+        main_resp = _make_url_mock(json.dumps({'commit': {'sha': 'abc123'}}).encode())
+        tree_resp = _make_url_mock(json.dumps({'tree': [{'path': 'config.yaml'}]}).encode())
+        config_resp = _make_url_mock(b'NPL:\n  base:\n    - [plus, way, 55555]\n')
+        osm_resp = _make_url_mock(b'<osm>xml</osm>')
+
+        mock_urlopen.side_effect = [pulls_resp, main_resp, tree_resp, config_resp, osm_resp]
+
+        result = lambda_handler({}, unittest.mock.MagicMock())
+
+        self.assertEqual(result['statusCode'], 200)
+        mock_s3.put_object.assert_called_once()
+        call_kwargs = mock_s3.put_object.call_args[1]
+        self.assertIn('way/55555', call_kwargs['Key'])
 
 
 def _make_url_mock(data: bytes) -> unittest.mock.MagicMock:


### PR DESCRIPTION
Refactor webhook/sweep.py so that `way` elements (added to config YAMLs in the last commit) are scanned, cached, and downloaded alongside `relation` elements.
